### PR TITLE
added PPF attribution in creating Contact-Congress

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         <p>
             Fight for the Future is the nonprofit Internet Freedom activism
             group best known for its work defeating SOPA/PIPA and advancing
-            <a href="https://www.battleforthenet.com/">Net Neutrality</a> (Open Internet Rules) in the United States.
+            <a href="https://www.battleforthenet.com/">Net Neutrality</a> (Open Internet Rules) in the United States. The underlying code for Contact-Congress was created in 2011 by the non-profit Participatory Politics Foundation (PPF) for their flagship site, OpenCongress.org.
         </p>
         <p>
             Now we're providing the best available methods for contacting Congress


### PR DESCRIPTION
Just wanted to have PPF's work on OpenCongress version 3 cited, the first open-source web pages that enabled digital transmissions through to Congressional web forms. Feel free to edit for spacing or as you see fit.
